### PR TITLE
feat: add GitHub Actions workflow for auto-merge PRs

### DIFF
--- a/.github/workflows/enable_pr_automerge.yaml
+++ b/.github/workflows/enable_pr_automerge.yaml
@@ -1,0 +1,16 @@
+name: Enable Auto merge PR
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable_automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge for PRs
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.PR_GITHUB_TOKEN}}


### PR DESCRIPTION
Creates a new GitHub Actions workflow that enables auto-merging 
of pull requests. This automation simplifies the process of 
merging PRs by utilizing the GitHub CLI to squash commits and 
delete the branch post-merge. The workflow runs on each 
pull_request