### PR TITLE
ci: update Go version in CI workflow matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test / Go ${{ matrix.go }} on ${{ matrix.os }}
     strategy:
       matrix:
-        go: ["1.23", "1.24"]
+        go: ["1.25"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Update the Go version in the CI workflow matrix to 1.25 to ensure  
compatibility with the latest features and improvements. This change  
maintains the testing environment up to date with the current stable  
release of Go.