### PR TITLE
fix(vcs): use reflect.Pointer instead of deprecated reflect.Ptr

### DIFF
--- a/vcs/bitbucket_client.go
+++ b/vcs/bitbucket_client.go
@@ -104,7 +104,7 @@ func (c *BitbucketClient) Do(ctx context.Context, req *http.Request, v any) (*ht
 
 func addOptions(originalUrl string, opts any) (string, error) {
   v := reflect.ValueOf(opts)
-  if v.Kind() == reflect.Ptr && v.IsNil() {
+  if v.Kind() == reflect.Pointer && v.IsNil() {
     return originalUrl, nil
   }
 


### PR DESCRIPTION
govet `inline` rule (latest golangci-lint) flags `reflect.Ptr` as a
deprecated alias for `reflect.Pointer`. Use the canonical constant.